### PR TITLE
add migration for 1.0.9

### DIFF
--- a/db_migrations/README.md
+++ b/db_migrations/README.md
@@ -10,9 +10,19 @@ From 1.0.9 onwards they should aim to preserve entered data through any changes.
 ## Use
 See nodejs db-migrations for details.
 
+From a blank database:
+1. apply the ../sql/deploySchema.sql to create the base schema
+2. db-m -e prod up
+3. (optional) clone to a dev DB for later testing
+
 Typically use the _db-m -e <dev|prod> up_ command to update to the latest version.
 
 Use of the _clone_db.sh_ can help with testing by cloning the in use DB to a temporary.
+
+## Create a new migration
+You may either copy an existing on or use _db-m create to-1-0-8_ comamnd and it will create the new migration file.
+The DTG group needs to be altered to ensure that the new migration is applied in the right order.
+
 
 ## User accounts
 Scripts and config are set to use the ${USER} environment variable for both username and password.

--- a/db_migrations/debug-harness.js
+++ b/db_migrations/debug-harness.js
@@ -1,0 +1,22 @@
+/*
+    Debug harness, so execute your migrations up to the one you want to test:
+    $ SRCDB=db_sosm ./clone_db.sh db_mig_test && ./db-m up -c 8
+    Then you can all this with debugging set
+    $ NODE_PATH=../www/node_modules nodejs --inspect-brk debug-harness.js
+    Then use your chrome (or similar) browser to go to:
+    chrome://inspect/#devices
+    and you can debug the latest migration.
+    It can worth using:
+    ...
+    debugger;
+    ...
+    To ensure you break at somewhere in your script because of the framework
+    around db-migrate.
+*/
+var DBMigrate = require('db-migrate');
+
+//getting an instance of dbmigrate
+var dbmigrate = DBMigrate.getInstance(true);
+
+//execute any of the API methods
+dbmigrate.up();

--- a/db_migrations/migrate-common.js
+++ b/db_migrations/migrate-common.js
@@ -1,0 +1,48 @@
+module.exports = {
+    DEBUG:  0,
+    VERBOSE: 1,
+    LOG: 2,
+    WARNING: 3,
+    ERROR: 4,
+    _logLevel : 2, // default to LOG, but can't refer back to value
+    setLogLevel : function(level)
+    {
+        this._logLevel = level;
+    },
+    /*
+        Timestamped log function to help debugging
+        async calls into the database or timing.
+        args:
+        msg - simple string message to append.
+        level - [optional, default: LOG] the message level for filtering
+    */
+    log: function (msg, level) {
+        var d = new Date();
+        var prefix = "LOG";
+        if ( typeof level == 'undefined' )
+        {
+            level = this.LOG;
+        }
+        switch(level){
+            case this.DEBUG:
+                prefix = "DEBUG";
+                break;
+            case this.VERBOSE:
+            case this.LOG:
+                prefix = "LOG";
+                break;
+            case this.WARNING:
+                prefix = "WARNING";
+                break;
+            case this.ERROR:
+                prefix = "ERROR!";
+                break;
+            default:
+                prefix = "<?>";
+                break;
+        }
+        if ( level >= this._logLevel ){
+            console.log(`<${prefix}> ${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}.${d.getMilliseconds()}\t${msg}`);
+        }
+    }
+}

--- a/db_migrations/migrations/20220803235758-init.js
+++ b/db_migrations/migrations/20220803235758-init.js
@@ -3,24 +3,26 @@
 var dbm;
 var type;
 var seed;
+var mc = require('../migrate-common.js');
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
+exports.setup = function (options, seedLink) {
   dbm = options.dbmigrate;
   type = dbm.dataType;
   seed = seedLink;
 };
 
-exports.up = function(db) {
+exports.up = function (db) {
   // Nothing as we just want to put a zero change in that puts migration
   // table in place
+  mc.log("Initialising migrations.");
   return null;
 };
 
-exports.down = function(db) {
+exports.down = function (db) {
   return null;
 };
 

--- a/db_migrations/migrations/20220804011601-to-1-0-2.js
+++ b/db_migrations/migrations/20220804011601-to-1-0-2.js
@@ -4,96 +4,109 @@ var dbm;
 var type;
 var seed;
 var async = require('async');
+var mc = require('../migrate-common.js');
+
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
+exports.setup = function (options, seedLink) {
+	dbm = options.dbmigrate;
+	type = dbm.dataType;
+	seed = seedLink;
 };
 
-exports.up = function(db, callback) {
-  // Table alterations
-  async.series([
-  db.dropTable.bind(db, 'SSMap', { ifExists: true } ),
-//  db.removeForeignKey.bind(db, 'SINMap', 'fk_SINMap_SIMap', { dropIndex: false }),
-//  db.dropTable.bind(db, 'SIMap', { ifExists: true } ),
-  db.dropTable.bind(db, 'subsystems', { ifExists: true } ),
-  db.dropTable.bind(db, 'SMap', { ifExists: true } ),
-  db.dropTable.bind(db, 'OSMap', { ifExists: true } ), // populated table so need to modify not drop
-//  db.removeColumn.bind(db, 'OSMap', 'quantity'), // may also need an alteration to foriegn key to cascade
-  db.dropTable.bind(db, 'OMap', { ifExists: true } ), // Populated table and modifications not needed
-  db.dropTable.bind(db, 'organisation', { ifExists: true } ), // populated table and modifications not needed
-  db.createTable.bind(db, 'SMap', {
-	  id_SMap: { type: 'int', auto_increment: true, notNull: true, primaryKey: true },
-	  parent: { type: 'int', notNull: true, foreignKey: { 
-		  name: 'fk_SMap_system_parent', table:'systems', mapping: 'id_system',
-		  rules: { onDelete: 'No Action', onUpdate: 'No Action'}
-	  		}
-	  },
-	  child: { type: 'int', notNull: true , foreignKey:{ 
-		  name: 'fk_SMap_system_child', table:'systems', mapping: 'id_system',
-		  rules: { onDelete: 'CASCADE', onUpdate: 'No Action'}
-	  		}
-	  }
-  }),
-  db.createTable.bind(db, 'organisation', {
-	  id_organisation : { type:'int', notNull: true, autoIncrement:true, primaryKey: true },
-	  name : { type:'varchar', length:200 },
-  }),
-  db.createTable.bind(db, 'OMap', {
-	  id_OMap : { type:'int', notNull: true, autoIncrement: true, primaryKey: true },
-	  parent : { type:'int', notNull: true, foreignKey: {
-		  name: 'fk_OMap_organisation_parent', table: 'organisation', mapping: 'id_organisation',
-		  rules: { onDelete : 'No Action', onUpdate: 'No action' }
-	  }},
-	  child : { type:'int', notNull: true, foreignKey: {
-		  name:  'fk_OMap_organisation_child', table: 'organisation', mapping: 'id_organisation',
-		  rules: { onDelete : 'CASCADE', onUpdate: 'No action' }
-	  }}
-  }),
-  db.createTable.bind(db, 'OSMap', {
-	  id_OSMap : { type:'int', notNull: true, autoIncrement: true, primaryKey: true },
-	  id_organisation: { type: 'int', notNull: true, 
-	  foreignKey: { name: 'fk_OSMap_organisation', table: 'organisation', mapping: 'id_organisation', 
-		  rules: { onDelete: 'No Action', onUpdate: 'No Action'}
-		  }
-	  },
-	  id_system: { type: 'int', notNull: true, 
-	  foreignKey: { name: 'fk_OSMap_systems', table: 'systems', mapping: 'id_system',
-		  rules: { onDelete: 'No Action', onUpdate: 'No Action'}
-		  }
-	  }
-  }),
-//  db.addColumn.bind(db, 'SIMap', 'name',{
-//	  type: 'varchar',
-//	  length: 45,
-//	  defaultValue: ''
-//  }),
-  db.addColumn.bind(db, 'networks', 'linkColor', {
-	  type: 'varchar',
-	  length : 45,
-	  defaultValue: 'blue'
-  }),
-  db.addColumn.bind(db, 'technologies', 'category', {
-	  type: 'varchar',
-	  length : 45,
-	  defaultValue: ''
-  }),
-  db.addColumn.bind(db, 'systems', 'updateTime', { type: 'bigint', defaultValue: 0 }),
-  db.addColumn.bind(db, 'systems', 'isSubsystem', { type: 'boolean', defaultValue: false }),
-  db.addColumn.bind(db, 'systems', 'distributedSubsystem', { type: 'boolean', defaultValue: false}),
-  db.addColumn.bind(db, 'interfaces', 'updateTime', { type: 'bigint', defaultValue: 0 }),
-  ], callback);
+exports.up = function (db, callback) {
+	mc.log("migrating to 1.0.2");
+	// Table alterations
+	async.series([
+		db.dropTable.bind(db, 'SSMap', { ifExists: true }),
+		//  db.removeForeignKey.bind(db, 'SINMap', 'fk_SINMap_SIMap', { dropIndex: false }),
+		//  db.dropTable.bind(db, 'SIMap', { ifExists: true } ),
+		db.dropTable.bind(db, 'subsystems', { ifExists: true }),
+		db.dropTable.bind(db, 'SMap', { ifExists: true }),
+		db.dropTable.bind(db, 'OSMap', { ifExists: true }), // populated table so need to modify not drop
+		//  db.removeColumn.bind(db, 'OSMap', 'quantity'), // may also need an alteration to foriegn key to cascade
+		db.dropTable.bind(db, 'OMap', { ifExists: true }), // Populated table and modifications not needed
+		db.dropTable.bind(db, 'organisation', { ifExists: true }), // populated table and modifications not needed
+		db.createTable.bind(db, 'SMap', {
+			id_SMap: { type: 'int', auto_increment: true, notNull: true, primaryKey: true },
+			parent: {
+				type: 'int', notNull: true, foreignKey: {
+					name: 'fk_SMap_system_parent', table: 'systems', mapping: 'id_system',
+					rules: { onDelete: 'No Action', onUpdate: 'No Action' }
+				}
+			},
+			child: {
+				type: 'int', notNull: true, foreignKey: {
+					name: 'fk_SMap_system_child', table: 'systems', mapping: 'id_system',
+					rules: { onDelete: 'CASCADE', onUpdate: 'No Action' }
+				}
+			}
+		}),
+		db.createTable.bind(db, 'organisation', {
+			id_organisation: { type: 'int', notNull: true, autoIncrement: true, primaryKey: true },
+			name: { type: 'varchar', length: 200 },
+		}),
+		db.createTable.bind(db, 'OMap', {
+			id_OMap: { type: 'int', notNull: true, autoIncrement: true, primaryKey: true },
+			parent: {
+				type: 'int', notNull: true, foreignKey: {
+					name: 'fk_OMap_organisation_parent', table: 'organisation', mapping: 'id_organisation',
+					rules: { onDelete: 'No Action', onUpdate: 'No action' }
+				}
+			},
+			child: {
+				type: 'int', notNull: true, foreignKey: {
+					name: 'fk_OMap_organisation_child', table: 'organisation', mapping: 'id_organisation',
+					rules: { onDelete: 'CASCADE', onUpdate: 'No action' }
+				}
+			}
+		}),
+		db.createTable.bind(db, 'OSMap', {
+			id_OSMap: { type: 'int', notNull: true, autoIncrement: true, primaryKey: true },
+			id_organisation: {
+				type: 'int', notNull: true,
+				foreignKey: {
+					name: 'fk_OSMap_organisation', table: 'organisation', mapping: 'id_organisation',
+					rules: { onDelete: 'No Action', onUpdate: 'No Action' }
+				}
+			},
+			id_system: {
+				type: 'int', notNull: true,
+				foreignKey: {
+					name: 'fk_OSMap_systems', table: 'systems', mapping: 'id_system',
+					rules: { onDelete: 'No Action', onUpdate: 'No Action' }
+				}
+			}
+		}),
+		//  db.addColumn.bind(db, 'SIMap', 'name',{
+		//	  type: 'varchar',
+		//	  length: 45,
+		//	  defaultValue: ''
+		//  }),
+		db.addColumn.bind(db, 'networks', 'linkColor', {
+			type: 'varchar',
+			length: 45,
+			defaultValue: 'blue'
+		}),
+		db.addColumn.bind(db, 'technologies', 'category', {
+			type: 'varchar',
+			length: 45,
+			defaultValue: ''
+		}),
+		db.addColumn.bind(db, 'systems', 'updateTime', { type: 'bigint', defaultValue: 0 }),
+		db.addColumn.bind(db, 'systems', 'isSubsystem', { type: 'boolean', defaultValue: false }),
+		db.addColumn.bind(db, 'systems', 'distributedSubsystem', { type: 'boolean', defaultValue: false }),
+		db.addColumn.bind(db, 'interfaces', 'updateTime', { type: 'bigint', defaultValue: 0 }),
+	], callback);
 };
 
-exports.down = function(db) {
-  return null;
+exports.down = function (db) {
+	return null;
 };
 
 exports._meta = {
-  "version": 1
+	"version": 1
 };

--- a/db_migrations/migrations/20220804011604-to-1-0-3.js
+++ b/db_migrations/migrations/20220804011604-to-1-0-3.js
@@ -4,43 +4,46 @@ var dbm;
 var type;
 var seed;
 var async = require('async');
+var mc = require('../migrate-common.js');
+
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
+exports.setup = function (options, seedLink) {
+	dbm = options.dbmigrate;
+	type = dbm.dataType;
+	seed = seedLink;
 };
 
-exports.up = function(db, callback) {
-  async.series([
-  	db.dropTable.bind(db, 'systemClassMap', { ifExists: true }),
-  	db.dropTable.bind(db, 'classes', { ifExists: true }),
-	db.removeColumn.bind(db, 'networks', 'linkColor'),
-	db.removeColumn.bind(db, 'networks', 'class'),
-	db.addColumn.bind(db, 'interfaceIssues', 'updateTime', {
-		type : 'bigint', defaultValue: 0
-	}),
-	db.removeForeignKey.bind(db,'quantities','fk_quantities_system', { dropIndex: false}),
-	db.addForeignKey.bind(db, 'quantities', 'systems', 'id_system', { 'id_system' : 'id_system' },
-		{ onDelete:'CASCADE', onUpdate: 'No Action'} ),
-	db.removeForeignKey.bind(db,'tags','fk_tags_systems', { dropIndex: false}),
-	db.runSql.bind(db, 'alter table tags drop key id_system_idx'), // not in schema update, and no standard api
-	db.addForeignKey.bind(db, 'tags', 'systems', 'fk_tags_systems', { 'id_system' : 'id_system' },
-		{ onDelete:'CASCADE', onUpdate: 'No Action'} ),
-	db.removeForeignKey.bind(db,'OSMap','fk_OSMap_systems', { dropIndex: false}),
-	db.addForeignKey.bind(db, 'OSMap', 'systems', 'fk_OSMap_systems', { 'id_system' : 'id_system' },
-		{ onDelete:'CASCADE', onUpdate: 'No Action'} )
+exports.up = function (db, callback) {
+	mc.log("migrating to 1.0.3");
+	async.series([
+		db.dropTable.bind(db, 'systemClassMap', { ifExists: true }),
+		db.dropTable.bind(db, 'classes', { ifExists: true }),
+		db.removeColumn.bind(db, 'networks', 'linkColor'),
+		db.removeColumn.bind(db, 'networks', 'class'),
+		db.addColumn.bind(db, 'interfaceIssues', 'updateTime', {
+			type: 'bigint', defaultValue: 0
+		}),
+		db.removeForeignKey.bind(db, 'quantities', 'fk_quantities_system', { dropIndex: false }),
+		db.addForeignKey.bind(db, 'quantities', 'systems', 'id_system', { 'id_system': 'id_system' },
+			{ onDelete: 'CASCADE', onUpdate: 'No Action' }),
+		db.removeForeignKey.bind(db, 'tags', 'fk_tags_systems', { dropIndex: false }),
+		db.runSql.bind(db, 'alter table tags drop key id_system_idx'), // not in schema update, and no standard api
+		db.addForeignKey.bind(db, 'tags', 'systems', 'fk_tags_systems', { 'id_system': 'id_system' },
+			{ onDelete: 'CASCADE', onUpdate: 'No Action' }),
+		db.removeForeignKey.bind(db, 'OSMap', 'fk_OSMap_systems', { dropIndex: false }),
+		db.addForeignKey.bind(db, 'OSMap', 'systems', 'fk_OSMap_systems', { 'id_system': 'id_system' },
+			{ onDelete: 'CASCADE', onUpdate: 'No Action' })
 	], callback);
 };
 
-exports.down = function(db) {
-  return null;
+exports.down = function (db) {
+	return null;
 };
 
 exports._meta = {
-  "version": 1
+	"version": 1
 };

--- a/db_migrations/migrations/20220804011618-to-1-0-4.js
+++ b/db_migrations/migrations/20220804011618-to-1-0-4.js
@@ -3,20 +3,23 @@
 var dbm;
 var type;
 var seed;
-var aysnc = require('async');
+var async = require('async');
+var mc = require('../migrate-common.js');
+
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
+exports.setup = function (options, seedLink) {
+	dbm = options.dbmigrate;
+	type = dbm.dataType;
+	seed = seedLink;
 };
 
-exports.up = function(db, callback) {
-	aysnc.series([
+exports.up = function (db, callback) {
+	mc.log("mibrating to 1.0.4");
+	async.series([
 		db.addColumn.bind(db, 'systems', 'category', {
 			type: 'varchar', length: 64
 		}),
@@ -27,15 +30,15 @@ exports.up = function(db, callback) {
 			type: 'varchar', length: 64
 		}),
 		db.removeForeignKey.bind(db, 'SINMap', 'fk_SINMap_SIMap', { dropIndex: false }),
-		db.addForeignKey.bind(db, 'SINMap', 'SIMap', 'fk_SINMap_SIMap', { 'id_SIMap' : 'id_SIMap' },
-			{ onDelete : 'CASCADE', onUpdate : 'No Action' })
+		db.addForeignKey.bind(db, 'SINMap', 'SIMap', 'fk_SINMap_SIMap', { 'id_SIMap': 'id_SIMap' },
+			{ onDelete: 'CASCADE', onUpdate: 'No Action' })
 	], callback);
 };
 
-exports.down = function(db) {
-  return null;
+exports.down = function (db) {
+	return null;
 };
 
 exports._meta = {
-  "version": 1
+	"version": 1
 };

--- a/db_migrations/migrations/20220804011620-to-1-0-5.js
+++ b/db_migrations/migrations/20220804011620-to-1-0-5.js
@@ -4,37 +4,46 @@ var dbm;
 var type;
 var seed;
 var async = require('async');
+var mc = require('../migrate-common.js');
+
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
+exports.setup = function (options, seedLink) {
+	dbm = options.dbmigrate;
+	type = dbm.dataType;
+	seed = seedLink;
 };
 
-exports.up = function(db, callback) {
+exports.up = function (db, callback) {
+	mc.log("migrating to 1.0.5");
 	async.series([
-		db.createTable.bind(db, 'AMap',{
-			id_AMap : { type: 'int', autoIncrement: true, primaryKey: true, notNull: true },
-			source : { type: 'int', notNull : true, foreignKey: {
-				name : 'fk_AMap_systems_source', table: 'systems', mapping:'id_system', rules: {
-					onDelete: 'CASCADE', onUpdate: 'No Action' }
-			}},
-			destination : { type: 'int', notNull: true, foreignKey: {
-				name : 'fk_AMap_systems_destination', table: 'systems', mapping:'id_system', rules: {
-					onDelete: 'CASCADE', onUpdate: 'No Action' }
-			}}
+		db.createTable.bind(db, 'AMap', {
+			id_AMap: { type: 'int', autoIncrement: true, primaryKey: true, notNull: true },
+			source: {
+				type: 'int', notNull: true, foreignKey: {
+					name: 'fk_AMap_systems_source', table: 'systems', mapping: 'id_system', rules: {
+						onDelete: 'CASCADE', onUpdate: 'No Action'
+					}
+				}
+			},
+			destination: {
+				type: 'int', notNull: true, foreignKey: {
+					name: 'fk_AMap_systems_destination', table: 'systems', mapping: 'id_system', rules: {
+						onDelete: 'CASCADE', onUpdate: 'No Action'
+					}
+				}
+			}
 		})
 	], callback);
 };
 
-exports.down = function(db) {
-  return null;
+exports.down = function (db) {
+	return null;
 };
 
 exports._meta = {
-  "version": 1
+	"version": 1
 };

--- a/db_migrations/migrations/20220805011620-to-1-0-6.js
+++ b/db_migrations/migrations/20220805011620-to-1-0-6.js
@@ -4,40 +4,43 @@ var dbm;
 var type;
 var seed;
 var async = require('async');
+var mc = require('../migrate-common.js');
+
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
+exports.setup = function (options, seedLink) {
+	dbm = options.dbmigrate;
+	type = dbm.dataType;
+	seed = seedLink;
 };
 
-exports.up = function(db, callback) {
+exports.up = function (db, callback) {
+	mc.log("migrating to 1.0.6");
 	async.series([
-		db.removeForeignKey.bind(db, 
-			"issuesToSystemsMap", "fk_issuesToSystemsMap_interfaceIssue", { dropIndex : false}
-			),
+		db.removeForeignKey.bind(db,
+			"issuesToSystemsMap", "fk_issuesToSystemsMap_interfaceIssue", { dropIndex: false }
+		),
 		db.addForeignKey.bind(db, "issuesToSystemsMap",
 			"interfaceIssues", "fk_issuesToSystemsMap_interfaceIssue",
-			{ "id_interfaceIssue" : "id_interfaceIssue"},
-			{ onDelete : 'CASCADE', onUpdate : "No Action"}),
-		db.removeForeignKey.bind(db, 
-			"issuesToSystemsMap", "fk_issuesToSystemsMap_system", { dropIndex : false}
-			),
+			{ "id_interfaceIssue": "id_interfaceIssue" },
+			{ onDelete: 'CASCADE', onUpdate: "No Action" }),
+		db.removeForeignKey.bind(db,
+			"issuesToSystemsMap", "fk_issuesToSystemsMap_system", { dropIndex: false }
+		),
 		db.addForeignKey.bind(db, "issuesToSystemsMap",
 			"systems", "fk_issuesToSystemsMap_system",
-			{ "id_system" : "id_system"},
-			{ onDelete : 'CASCADE', onUpdate : "No Action"})			
+			{ "id_system": "id_system" },
+			{ onDelete: 'CASCADE', onUpdate: "No Action" })
 	], callback);
 };
 
-exports.down = function(db) {
-  return null;
+exports.down = function (db) {
+	return null;
 };
 
 exports._meta = {
-  "version": 1
+	"version": 1
 };

--- a/db_migrations/migrations/20220907003110-to-1-0-7.js
+++ b/db_migrations/migrations/20220907003110-to-1-0-7.js
@@ -1,39 +1,41 @@
 'use strict';
-var async = require('async');
 
 var dbm;
 var type;
 var seed;
+var async = require('async');
+var mc = require('../migrate-common.js');
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
+exports.setup = function (options, seedLink) {
+	dbm = options.dbmigrate;
+	type = dbm.dataType;
+	seed = seedLink;
 };
 
-exports.up = function(db, callback) {
+exports.up = function (db, callback) {
+	mc.log("migrating to 1.0.7");
 	async.series([
-		db.createTable.bind(db, 'families',{
-			id_family : { type: 'int', autoIncrement: true, primaryKey: true, notNull: true },
-			name : { type: 'varchar', length : 60, notNull : true},
-			description : { type: 'longtext', notNull : false}
-			}
+		db.createTable.bind(db, 'families', {
+			id_family: { type: 'int', autoIncrement: true, primaryKey: true, notNull: true },
+			name: { type: 'varchar', length: 60, notNull: true },
+			description: { type: 'longtext', notNull: false }
+		}
 		),
-		db.addColumn.bind(db, 'systems', 'id_family', { type : 'int' }),
-		db.addColumn.bind(db, 'systems', 'version', { type : 'varchar', length : 60 }),
-		db.addForeignKey.bind(db, 'systems', 'families', 'fk_systems_families', { 'id_family' : 'id_family' },
-			{ onDelete : 'CASCADE', onUpdate : 'No Action' }),
+		db.addColumn.bind(db, 'systems', 'id_family', { type: 'int' }),
+		db.addColumn.bind(db, 'systems', 'version', { type: 'varchar', length: 60 }),
+		db.addForeignKey.bind(db, 'systems', 'families', 'fk_systems_families', { 'id_family': 'id_family' },
+			{ onDelete: 'CASCADE', onUpdate: 'No Action' }),
 	], callback);
 };
 
-exports.down = function(db) {
-  return null;
+exports.down = function (db) {
+	return null;
 };
 
 exports._meta = {
-  "version": 1
+	"version": 1
 };

--- a/db_migrations/migrations/20220925232322-to-1-0-8.js
+++ b/db_migrations/migrations/20220925232322-to-1-0-8.js
@@ -3,7 +3,8 @@
 var dbm;
 var type;
 var seed;
-var aysnc = require('async');
+var async = require('async');
+var mc = require('../migrate-common.js');
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
@@ -20,7 +21,8 @@ exports.setup = function(options, seedLink) {
   consistency.
 */
 exports.up = function(db, callback) {
-  aysnc.series([
+  mc.log("migrating to 1.0.8");
+  async.series([
 		db.createTable.bind(db, 'cimMap', {
       id_cimMap : { type : 'int', notNull : true, autoIncrement : true, primaryKey : true },
       id_system : { type : 'int', notNull : true, foreignKey : {

--- a/db_migrations/migrations/20221019232322-to-1-0-9.js
+++ b/db_migrations/migrations/20221019232322-to-1-0-9.js
@@ -1,0 +1,199 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var async = require('async');
+var mc = require('../migrate-common.js');
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+/*
+  This migration is likely to be overtaken by design changes, but is provided for
+  consistency.
+*/
+exports.up = function (db, callback) {
+  mc.log("migrating to 1.0.9");
+  // runSql used as to rename a primary key in use as a foreign key
+  // should be done via dropping foreign the key, renaming and then
+  // readding, MySQL 'RENAME COLUMN' is shorthand for this, but is
+  // probably not portable.
+  async.series([
+    db.renameTable.bind(db, "networks", "links"),
+    (cb) => {
+      ["links", "SINMap"].forEach((table) => {
+        console.log("table " + table);
+        db.runSql(
+          "ALTER TABLE " + table + " RENAME COLUMN id_network TO id_link",
+        );
+      });
+      cb(null);
+    },
+    db.renameTable.bind(db, "SINMap", "SystemInterfaceToLinkMap"),
+    db.renameColumn.bind(db, "SystemInterfaceToLinkMap", "id_SINMap", "id_SILMap"),
+
+    db.renameTable.bind(db, "SIMap", "InterfaceToSystemMap"),
+    db.runSql.bind(db,
+      "ALTER TABLE InterfaceToSystemMap RENAME COLUMN id_SIMap to id_ISMap"
+    ),
+
+    db.createTable.bind(db, "technologyCategories",
+      {
+        id_techCategory: {
+          type: "int",
+          autoIncrement: true,
+          primaryKey: true,
+          notNull: true
+        },
+        name: { type: "varchar", length: 45, notNull: true },
+        color: { type: "varchar", length: 45, notNull: true }
+      }
+    ),
+    db.addColumn.bind(db, "technologies", "id_techCategory",
+      {
+        type: "int",
+        notNull: true, foreignKey: {
+          name: 'fk_technologies_techCategory_idx',
+          table: 'technologyCategories',
+          mapping: 'id_techCategory', rules: {
+            onDelete: 'No Action', onUpdate: 'No Action'
+          }
+        }
+      }
+    ),
+    async () => {
+      var cb = arguments[arguments.len - 1];
+//      mc.log("Calling foreach");
+      var fall = [];
+      ["Red",
+        "Green",
+        "Blue"
+      ].forEach((val) => {
+//        log("Calling insert for " + val);
+        db.insert(
+          "technologyCategories", ["name", "color"],
+          [val, val.toLowerCase()]
+        );
+//        log("Selecting for " + val);
+        function update_table(err, results) {
+          if (err) {
+            log("Error in select id tech category " + err);
+            return;
+          }
+//          log(`select for ${val} got ${results[0]["id"]} updating`);
+          var p = db.runSql("UPDATE technologies SET id_techCategory = ? " +
+            " WHERE category = ?", [results[0]["id"], val.toLowerCase()]
+          );
+          fall.push(p);
+        };
+        var p = db.runSql("SELECT id_techCategory as id FROM technologyCategories WHERE name = ?", val, update_table);
+        fall.push(p);
+      });
+//      log("For each call completed, removing column after wait");
+      await Promise.all(fall);
+      db.removeColumn("technologies", "category");
+//      log("Column remove done");
+      if (typeof cb == "function") {
+        cb(null);
+      }
+    },
+    db.createTable.bind(db, 'paramGroups', {
+      id_paramGroup: { type: 'int', autoIncrement: true, primaryKey: true, notNull: true },
+      name: { type: 'varchar', length: 45, notNull: true },
+      description: { type: 'longtext' }
+    }),
+    db.createTable.bind(db, 'paramDefinitions', {
+      id_paramDefinition: { type: 'int', autoIncrement: true, primaryKey: true, notNull: true },
+      id_paramGroup: {
+        type: 'int', notNull: true, foreignKey: {
+          name: 'fk_paramDefinitions_paramGroup_idx',
+          table: 'paramGroups',
+          mapping: 'id_paramGroup', rules: {
+            onDelete: 'No Action', onUpdate: 'No Action'
+          }
+        }
+      },
+      name: { type: 'varchar', length: 45 },
+      description: { type: 'longtext' },
+      paramType: { type: 'varchar', length: 45 },
+      options: { type: 'longtext' },
+      applicableToSystem: { type: 'boolean', default: false },
+      applicableToInterface: { type: 'boolean', default: false },
+      applicableToLink: { type: 'boolean', default: false },
+      applicableToTechnology: { type: 'boolean', default: false }
+    }),
+    db.createTable.bind(db, 'params', {
+      id_param: { type: 'int', autoIncrement: true, primaryKey: true, notNull: true },
+      id_paramDefinition: {
+        type: 'int', notNull: true, foreignKey: {
+          name: 'fk_params_paramDefinitions_idx',
+          table: 'paramDefinitions',
+          mapping: 'id_paramDefinition', rules: {
+            onDelete: 'CASCADE', onUpdate: 'No Action'
+          }
+        }
+      },
+      value: { type: 'longtext' },
+      id_system: {
+        type: 'int', notNull: false, foreignKey: {
+          name: 'fk_params_systems_idx',
+          table: 'systems',
+          mapping: 'id_system', rules: {
+            onDelete: 'CASCADE', onUpdate: 'No Action'
+          }
+        }
+      },
+      id_interface: {
+        type: 'int', notNull: false, foreignKey: {
+          name: 'fk_params_interfaces_idx',
+          table: 'interfaces',
+          mapping: 'id_interface', rules: {
+            onDelete: 'CASCADE', onUpdate: 'No Action'
+          }
+        }
+      },
+      id_link: {
+        type: 'int', notNull: false, foreignKey: {
+          name: 'fk_params_links_idx',
+          table: 'links',
+          mapping: 'id_link', rules: {
+            onDelete: 'CASCADE', onUpdate: 'No Action'
+          }
+        }
+      },
+      id_technology: {
+        type: 'int', notNull: false, foreignKey: {
+          name: 'fk_params_technologies_idx',
+          table: 'technologies',
+          mapping: 'id_technology', rules: {
+            onDelete: 'CASCADE', onUpdate: 'No Action'
+          }
+        }
+      },
+    }),
+    db.addColumn.bind(db, 'SystemInterfaceToLinkMap', 'isPrimary',
+      { type: 'boolean' }),
+    db.runSql.bind(db, 'UPDATE SystemInterfaceToLinkMap set isPrimary=true WHERE category = "primary"'),
+    db.runSql.bind(db, 'UPDATE SystemInterfaceToLinkMap set isPrimary=false WHERE category = "alternate"'),
+    db.runSql.bind(db, "DELETE FROM SystemInterfaceToLinkMap WHERE category = 'incapable'"),
+    db.removeColumn.bind(db, 'SystemInterfaceToLinkMap', 'category')
+  ], callback);
+
+
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};


### PR DESCRIPTION
Formatted and aligned prior migrations with changes from working on 1.0.9.

Added 1.0.9 migration.

Added harness to allow debugging of migrations when they are being particularly tricky (i.e. promises and ensuring synchronous operation).