### PR TITLE
Refactor server app; add data-pack import/export, docs, and Docker/dev updates (default port 3001)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,12 @@
-APP_PORT=3000
+# App
+APP_PORT=3001
+NODE_ENV=development
 
-DB_DIALECT=mysql  # or postgres
-DB_HOST=db
-DB_PORT=3306
+# Database
 DB_NAME=db_sosm
 DB_USER=sosmUser
 DB_PASS=sosm_pass
 DB_ROOT_PASS=rootpass
-LOG_LEVEL=debug # can be: fatal, error, warn, info, debug, trace
-NODE_ENV=development # can be: development, production
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DIALECT=mysql

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # system-of-systems-modeller
+
 System-of-systems-modeller (SOSM) is a NodeJS-based web app supported by an SQL database (MySQL) which allows a user to model nodes, their interfaces and the ways in which they connect. SOSM uses a number of client-side JS libraries which attempts to provide a clean UI, whilst also providing a clear graphical representation of the system, or the particular view of the system that the user is currently interested in.
 
 ## SOSM Terms
@@ -7,6 +8,66 @@ SOSM defines the following terms:
 - Interface. The means by which a platform (system) connects to other platforms (systems).
 - Network. The link established between two or more interfaces.
 - Feature. The technology used by a network as well as the technology that can be implemented by an interface.
+
+## Quick start (Docker)
+
+> Default app host port is **3001** so it does not clash with existing services on port 80.
+
+### 1) Create environment file
+```bash
+cp .env.example .env
+```
+
+Optional edits in `.env`:
+- `APP_PORT` (default 3001)
+- `DB_NAME`, `DB_USER`, `DB_PASS`, `DB_ROOT_PASS`
+
+### 2) Start SOSM + database
+```bash
+docker compose up -d
+```
+
+### 3) Verify services
+```bash
+docker compose ps
+```
+
+Network note: Compose now creates a dedicated bridge network named `sosm_net` for container-to-container communication (`server` ↔ `db` ↔ `adminer`).
+
+### 4) Open the app
+- App: `http://localhost:${APP_PORT:-3001}`
+- Adminer (optional): `http://localhost:8080`
+
+### 5) (Optional) Load sample data
+```bash
+./scripts/deployTestData.sh
+```
+
+### 6) Stop
+```bash
+docker compose down
+```
+
+## Quick start (no Docker DB)
+
+If you already run MySQL on the host, SOSM scripts can use that DB instead of Docker:
+1. Configure `.env` with your host DB values.
+2. Run app with Node:
+   ```bash
+   npm install
+   npm run dev
+   ```
+
+## Offline data packs (private local data)
+
+Use data packs to quickly export/import local working data without committing it to Git:
+
+```bash
+npm run data:export
+PACK=./private/data-packs/<your-pack>.tar.gz npm run data:import
+```
+
+See full guide: [`docs/dev/dataPacks.md`](./docs/dev/dataPacks.md).
 
 ## SOSM Dependencies
 SOSM requires a number of external dependencies to function. Client side external dependencies can be found within /www/index.html. Client side external dependencies include:

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ cp .env.example .env
 ```
 
 Optional edits in `.env`:
-- `APP_PORT` (default 3001)
+- `APP_PORT` (default 3001, host port)
 - `DB_NAME`, `DB_USER`, `DB_PASS`, `DB_ROOT_PASS`
+
+The container listens on port `3000`; Compose maps `${APP_PORT}:3000`.
 
 ### 2) Start SOSM + database
 ```bash

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       DB_NAME: ${DB_NAME:-sosm}
       DB_USER: ${DB_USER:-sosmuser}
       DB_PASS: ${DB_PASS:-sosmpass}
-      PORT: ${APP_PORT:-3001}
+      PORT: 3000
       NODE_ENV: development
     volumes:
       - ./:/app

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,8 @@ services:
       retries: 10
     ports:
       - "${DB_PORT:-3306}:3306"
+    networks:
+      - sosm_net
 
   server:
     image: node:20-alpine
@@ -33,7 +35,7 @@ services:
       DB_NAME: ${DB_NAME:-sosm}
       DB_USER: ${DB_USER:-sosmuser}
       DB_PASS: ${DB_PASS:-sosmpass}
-      PORT: ${APP_PORT:-3000}
+      PORT: ${APP_PORT:-3001}
       NODE_ENV: development
     volumes:
       - ./:/app
@@ -44,7 +46,9 @@ services:
       db:
         condition: service_healthy
     ports:
-      - "${APP_PORT:-3000}:3000"
+      - "${APP_PORT:-3001}:3000"
+    networks:
+      - sosm_net
 
   # Optional: web DB UI at http://localhost:8080
   adminer:
@@ -54,6 +58,13 @@ services:
       - db
     ports:
       - "8080:8080"
+    networks:
+      - sosm_net
 
 volumes:
   dbdata: {}
+
+networks:
+  sosm_net:
+    name: sosm_net
+    driver: bridge

--- a/docs/dev/dataPacks.md
+++ b/docs/dev/dataPacks.md
@@ -1,0 +1,43 @@
+# Offline Data Packs
+
+Data packs are a fast import/export mechanism for private local development data.
+
+## Why
+- Keep private modelling data out of Git.
+- Reduce downtime during refactor by quickly restoring a known dataset.
+- Support air-gapped and offline workflows.
+
+## Export
+From repo root:
+
+```bash
+npm run data:export
+```
+
+Optional environment variables:
+- `PACK_NAME=<name>` custom output folder/archive name.
+- `OUT_DIR=<path>` output base directory (default `./private/data-packs`).
+
+Output:
+- `<OUT_DIR>/<PACK_NAME>.tar.gz`
+- Archive contains:
+  - `schema.sql`
+  - `images/`
+  - `manifest.json`
+
+## Import
+From repo root:
+
+```bash
+PACK=./private/data-packs/<PACK_NAME>.tar.gz npm run data:import
+```
+
+Import process:
+1. Unpacks archive into a temp folder.
+2. Creates temporary test-case folder under `testData/_import_tmp`.
+3. Uses existing `scripts/deployTestData.sh` workflow.
+4. Cleans up temporary files.
+
+## Notes
+- `.gitignore` already excludes `private/`; keep private data packs there.
+- Data packs are data-only snapshots and should be treated as sensitive.

--- a/docs/dev/deploySOSM.md
+++ b/docs/dev/deploySOSM.md
@@ -1,12 +1,22 @@
 # Deploy SOSM
 
-This guide explains how to **deploy an empty SOSM instance** to a prepared development environment. If the **development environment** is not yet configured, see [`setupEnvironment.md`](./setupEnvironment.md). Once SOSM is deployed, it can be populated with [test data](./deployTestData.md), if required.
+This guide explains how to deploy SOSM in a development environment.
 
-## Hybrid Dev Environment
+## Recommended (Docker)
+Use the helper script:
 
-Run `docker compose up db -d` to build the container, setup the database volume and run the container.
-Verify operation of the container with `docker ps`.
+```bash
+./scripts/dev-up.sh
+```
 
+Equivalent direct command:
+
+```bash
+docker compose up --build -d
+```
+
+## Legacy wrapper
+`./scripts/deploySOSM.sh` is kept as a compatibility wrapper and now delegates to `./scripts/dev-up.sh`.
 
 ## Port configuration
 If your host already uses port 80, set `APP_PORT` in `.env` (for example `APP_PORT=3001`) before running Compose. The host port is configured in `docker-compose.yaml`; Dockerfile `EXPOSE` does not publish ports by itself.

--- a/docs/dev/deploySOSM.md
+++ b/docs/dev/deploySOSM.md
@@ -6,3 +6,7 @@ This guide explains how to **deploy an empty SOSM instance** to a prepared devel
 
 Run `docker compose up db -d` to build the container, setup the database volume and run the container.
 Verify operation of the container with `docker ps`.
+
+
+## Port configuration
+If your host already uses port 80, set `APP_PORT` in `.env` (for example `APP_PORT=3001`) before running Compose. The host port is configured in `docker-compose.yaml`; Dockerfile `EXPOSE` does not publish ports by itself.

--- a/docs/dev/deployTestData.md
+++ b/docs/dev/deployTestData.md
@@ -20,3 +20,18 @@ Install the MySQL client first:
 ```bash
 sudo apt-get update && sudo apt-get install -y mysql-client
 ```
+
+
+## Troubleshooting
+### Docker permission denied
+If you see `permission denied while trying to connect to the docker API`, your user cannot access Docker daemon.
+
+Use one of:
+```bash
+sudo ./scripts/deployTestData.sh
+```
+Or add your user to docker group and re-login:
+```bash
+sudo usermod -aG docker $USER
+newgrp docker
+```

--- a/docs/dev/deployTestData.md
+++ b/docs/dev/deployTestData.md
@@ -1,9 +1,22 @@
 # Deploy Test Data
 
 `/scripts/deployTestData.sh` performs the following actions:
-- Checks for the presence of the grep command (required to run the script).
-- Loads the `.env` for the database name and credentials
-- Identifies the environment in which the script exists (database running natively or in a container)
-- Checks database connectivity
-- Asks the user if they want to continue
-  - If yes: Rebuilds the schema, loads test data into the database and copies images from `/testData/images/` to `/public/images`
+- Loads `.env` for database name and credentials.
+- Detects whether Docker Compose is available.
+- If Docker is available and `db` is not running, attempts to start `db` automatically.
+- If Docker DB is unavailable, falls back to host MySQL (`mysql` CLI required).
+- Checks database connectivity.
+- Prompts for a test case folder from `/testData`.
+- Applies all `.sql` files in the selected folder.
+- Copies images from the selected case's `/images` folder into `/public/images`.
+
+## Typical usage
+```bash
+./scripts/deployTestData.sh
+```
+
+## If host MySQL fallback is used
+Install the MySQL client first:
+```bash
+sudo apt-get update && sudo apt-get install -y mysql-client
+```

--- a/docs/dev/runSOSM.md
+++ b/docs/dev/runSOSM.md
@@ -66,7 +66,7 @@ docker compose logs -f adminer
 docker compose logs -f www   # if your app service is named "www" in compose
 ```
 
-> Adminer (optional DB UI) is at **http://localhost:8080** once up. The app listens on **http://localhost:${APP_PORT:-3000}** (default 3000).
+> Adminer (optional DB UI) is at **http://localhost:8080** once up. The app listens on **http://localhost:${APP_PORT:-3001}** (default 3001).
 
 ---
 
@@ -127,13 +127,31 @@ docker compose exec db sh -c 'mysqldump -u${DB_USER:-sosmUser} -p${DB_PASS:-sosm
 
 ---
 
+## 4) Configure app port (non-80)
+
+If port **80** is already in use on your host, keep SOSM on another host port (default now: **3001**).
+
+1. Set `APP_PORT` in `.env`:
+```bash
+APP_PORT=3001
+```
+2. Restart compose:
+```bash
+docker compose up -d
+```
+
+### Where to change it later
+- Change the host/container mapping in `docker-compose.yaml` via `ports: - "${APP_PORT:-3001}:3000"`.
+- Update `.env` `APP_PORT` for per-environment override.
+- You **normally do not change this in Dockerfile**. `EXPOSE` is documentation metadata; published host port is controlled by Compose/`docker run -p`.
+
 ## 5) Images & backups via the app
 
 - `GET /backup.txt` – generates SQL insert statements to replicate current DB contents.
 - `GET /images.json` – lists images available to the app.
 - `/www/assets`, `/www/images` – app‑served static assets.
 
-> With Docker: `curl http://localhost:3000/backup.txt`
+> With Docker: `curl http://localhost:${APP_PORT:-3001}/backup.txt`
 
 ---
 

--- a/docs/dev/runSOSM.md
+++ b/docs/dev/runSOSM.md
@@ -63,10 +63,10 @@ docker compose logs -f
 # service‑specific
 docker compose logs -f db
 docker compose logs -f adminer
-docker compose logs -f www   # if your app service is named "www" in compose
+docker compose logs -f server
 ```
 
-> Adminer (optional DB UI) is at **http://localhost:8080** once up. The app listens on **http://localhost:${APP_PORT:-3001}** (default 3001).
+> Adminer (optional DB UI) is at **http://localhost:8080** once up. The app is exposed on **http://localhost:${APP_PORT:-3001}** (default 3001) with Compose mapping host `${APP_PORT}` to container port `3000`.
 
 ---
 
@@ -171,12 +171,12 @@ docker stats
 ### Restart a single service
 ```bash
 docker compose restart db
-docker compose restart www
+docker compose restart server
 ```
 
 ### Exec into the app container
 ```bash
-docker compose exec www sh
+docker compose exec server sh
 ps aux
 node -v
 ```
@@ -196,6 +196,10 @@ node -v
 
 - **Port already in use**
   - Change `APP_PORT` in `.env` (e.g., 3001) and re‑`up`.
+
+- **Adminer works but app does not respond**
+  - Check Compose mapping is `"${APP_PORT:-3001}:3000"` and app `PORT` inside container is `3000`.
+  - Verify with `docker compose ps` and `docker compose logs -f server`.
 
 - **Need a clean slate**
   - `docker compose down -v` to remove containers and volumes, then `docker compose up -d`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 3. (Optional) [Deploy test data](./dev/deployTestData.md)
 4. [Run SOSM](./dev/runSOSM.md)
 5. (Optional) [Backup test data](./dev/backupTestData.md)
+6. (Optional) [Offline data packs](./dev/dataPacks.md)
 
 
 ## [Setup environment](./dev/setupEnvironment.md)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "server/app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon server/index.js"
+    "dev": "nodemon server/index.js",
+    "data:export": "bash scripts/dataPackExport.sh",
+    "data:import": "bash scripts/dataPackImport.sh"
   },
   "author": "",
   "license": "ISC",

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -244,17 +244,36 @@ async function getGraphData(cy){
 		console.log('Passed to graph.json:', postData);
 		console.log('Response:', result)
 
-		
+		let graphElements = [];
+		let stats = {};
+
+		// Legacy expected shape: [elements[], statsObj]
+		if (Array.isArray(result)) {
+			graphElements = Array.isArray(result[0]) ? result[0] : [];
+			stats = result[1] || {};
+		}
+		// Graceful handling for object responses (e.g. { data: {} } when no graph data)
+		else if (result && typeof result === 'object') {
+			if (Array.isArray(result.data)) {
+				graphElements = result.data;
+			} else if (result.data && Array.isArray(result.data.elements)) {
+				graphElements = result.data.elements;
+			} else {
+				graphElements = [];
+			}
+			stats = result.stats || {};
+		}
 
 		//Handle the stats data as well
-		sosm = result[1];
+		sosm = stats;
 
-		if (cy) { 
-			cy.add(result[0]);
+		if (cy) {
+			cy.elements().remove();
+			if (graphElements.length > 0) {
+				cy.add(graphElements);
+			}
 			cy.layout(graphSettings.getLayout()).run();
-			
-			
-			//cy.stop(true, true); 
+			//cy.stop(true, true);
 		}
 		
 		return true;

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -41,3 +41,10 @@ For ease of use, run `eval "$(ssh-agent -s)"` and `ssh-add` each time the system
 
 
 ## Annoying Problems
+
+
+## Current status (Docker workflow)
+- `dev-up.sh`: primary local start command (`docker compose up --build -d`).
+- `dev-down.sh`: primary local stop command (`docker compose down`).
+- `restart.sh`: pull + restart helper.
+- `deploySOSM.sh` (deprecated wrapper): kept for compatibility; delegates to `dev-up.sh`.

--- a/scripts/backupTestData.sh
+++ b/scripts/backupTestData.sh
@@ -49,7 +49,7 @@ load_env() {
 
 docker_db_running() {
   if ! command -v docker >/dev/null 2>&1; then return 1; fi
-  if ! command -v docker compose >/dev/null 2>&1; then return 1; fi
+  docker compose version >/dev/null 2>&1 || return 1
   local cid
   cid="$(cd "${REPO_ROOT}" && docker compose -f "${COMPOSE_FILE}" ps -q db || true)"
   [[ -n "${cid}" ]] || return 1

--- a/scripts/backupTestData.sh
+++ b/scripts/backupTestData.sh
@@ -195,6 +195,9 @@ main() {
 
   info "Checking database connectivity…"
   if docker_db_running; then
+    if ! docker info >/dev/null 2>&1; then
+      die "Docker is installed but not accessible by this user. Try running with sudo or add your user to the docker group."
+    fi
     info "Docker DB detected (service: db)."
     mysql_probe_docker
   else

--- a/scripts/dataPackExport.sh
+++ b/scripts/dataPackExport.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Export a portable local data pack for offline development.
+# Contents:
+#   - schema.sql (data-only dump)
+#   - images/
+#   - manifest.json
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+PACK_NAME="${PACK_NAME:-local-${TIMESTAMP}}"
+OUT_DIR="${OUT_DIR:-${REPO_ROOT}/private/data-packs}"
+WORK_DIR="${OUT_DIR}/${PACK_NAME}"
+
+"${SCRIPT_DIR}/backupTestData.sh" --yes --dest "${WORK_DIR}"
+
+cat > "${WORK_DIR}/manifest.json" <<JSON
+{
+  "pack_name": "${PACK_NAME}",
+  "created_utc": "${TIMESTAMP}",
+  "format": "sosm-data-pack-v1",
+  "contents": ["schema.sql", "images/"]
+}
+JSON
+
+(
+  cd "${OUT_DIR}"
+  tar -czf "${PACK_NAME}.tar.gz" "${PACK_NAME}"
+)
+
+echo "Created data pack: ${OUT_DIR}/${PACK_NAME}.tar.gz"

--- a/scripts/dataPackImport.sh
+++ b/scripts/dataPackImport.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Import a portable local data pack for offline development.
+# Usage:
+#   PACK=<path/to/pack.tar.gz> ./scripts/dataPackImport.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PACK="${PACK:-}"
+
+if [[ -z "${PACK}" ]]; then
+  echo "ERROR: PACK is required. Example: PACK=./private/data-packs/local-*.tar.gz ./scripts/dataPackImport.sh" >&2
+  exit 1
+fi
+
+[[ -f "${PACK}" ]] || { echo "ERROR: Pack not found: ${PACK}" >&2; exit 1; }
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+tar -xzf "${PACK}" -C "${TMP_DIR}"
+PACK_DIR="$(find "${TMP_DIR}" -mindepth 1 -maxdepth 1 -type d | head -n1)"
+
+[[ -n "${PACK_DIR}" ]] || { echo "ERROR: Invalid pack archive structure" >&2; exit 1; }
+[[ -f "${PACK_DIR}/schema.sql" ]] || { echo "ERROR: schema.sql missing from pack" >&2; exit 1; }
+
+# Deploy using temporary folder structure expected by deployTestData.sh
+TMP_TEST_DIR="${REPO_ROOT}/testData/_import_tmp"
+rm -rf "${TMP_TEST_DIR}"
+mkdir -p "${TMP_TEST_DIR}"
+cp "${PACK_DIR}/schema.sql" "${TMP_TEST_DIR}/01_import.sql"
+if [[ -d "${PACK_DIR}/images" ]]; then
+  cp -R "${PACK_DIR}/images" "${TMP_TEST_DIR}/images"
+fi
+
+TEST_NAME="_import_tmp" YES=true "${SCRIPT_DIR}/deployTestData.sh"
+rm -rf "${TMP_TEST_DIR}"
+
+echo "Imported data pack: ${PACK}"

--- a/scripts/deploySOSM.sh
+++ b/scripts/deploySOSM.sh
@@ -1,20 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-### Development environment deployment
-read -n 1 -p "Do you wish to deploy a development environment (y/Y): " continue
-echo ""
-if [[ $continue =~ [yY] ]]; then
+# Deprecated compatibility wrapper.
+# Use ./scripts/dev-up.sh for Docker-based local deployment.
 
-	read -n 1 -p "Install required npm packages (y/Y): " continue
-	echo ""
-	if [[ $continue =~ [yY] ]]; then
-		#Install required packages
-		npm --prefix $PWD/../www install
-  
-  		#Nodemon install?
-	fi
-else
-	#Deploy a production server (NGINX?)
-	echo "Deploying a production server has not been considered at this stage."
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+cat <<MSG
+[DEPRECATED] scripts/deploySOSM.sh is no longer required for Docker-based setup.
+Use: ./scripts/dev-up.sh
+This wrapper will now call dev-up.sh.
+MSG
+
+"${SCRIPT_DIR}/dev-up.sh"

--- a/scripts/deployTestData.sh
+++ b/scripts/deployTestData.sh
@@ -67,9 +67,12 @@ docker_db_running() {
 ensure_docker_db() {
   command -v docker >/dev/null 2>&1 || return 1
   docker compose version >/dev/null 2>&1 || return 1
+  if ! docker info >/dev/null 2>&1; then
+    die "Docker is installed but not accessible by this user. Try 'sudo ./scripts/deployTestData.sh' or add your user to the docker group."
+  fi
   if docker_db_running; then return 0; fi
   info "Docker Compose detected but 'db' is not running. Attempting to start it…"
-  (cd "${REPO_ROOT}" && docker compose -f "${COMPOSE_FILE}" up -d db) >/dev/null
+  (cd "${REPO_ROOT}" && docker compose -f "${COMPOSE_FILE}" up -d db)
   docker_db_running
 }
 

--- a/scripts/deployTestData.sh
+++ b/scripts/deployTestData.sh
@@ -50,14 +50,10 @@ load_env() {
 
 docker_db_running() {
   # Returns 0 if a Compose service named "db" is up
-  if ! command -v docker >/dev/null 2>&1; then
-    return 1
-  fi
-  if ! command -v docker compose >/dev/null 2>&1; then
-    return 1
-  fi
+  if ! command -v docker >/dev/null 2>&1; then return 1; fi
+  docker compose version >/dev/null 2>&1 || return 1
   # Run from repo root so compose can see the file
-  echo "Running: docker compose -f ${COMPOSE_FILE} ps -q db"
+  info "Running: docker compose -f ${COMPOSE_FILE} ps -q db"
   (cd "${REPO_ROOT}" && docker compose -f "${COMPOSE_FILE}" ps -q db) >/dev/null 2>&1 || return 1
   local cid
   cid="$(cd "${REPO_ROOT}" && docker compose -f "${COMPOSE_FILE}" ps -q db || true)"
@@ -66,6 +62,15 @@ docker_db_running() {
   local st
   st="$(docker inspect -f '{{.State.Running}}' "${cid}" 2>/dev/null || echo false)"
   [[ "${st}" == "true" ]]
+}
+
+ensure_docker_db() {
+  command -v docker >/dev/null 2>&1 || return 1
+  docker compose version >/dev/null 2>&1 || return 1
+  if docker_db_running; then return 0; fi
+  info "Docker Compose detected but 'db' is not running. Attempting to start it…"
+  (cd "${REPO_ROOT}" && docker compose -f "${COMPOSE_FILE}" up -d db) >/dev/null
+  docker_db_running
 }
 
 mysql_exec_host() {
@@ -187,8 +192,12 @@ main() {
   load_env
 
   info "Hybrid check: detecting Docker 'db' service…"
-  if docker_db_running; then info "MySQL is running in Docker (service: db)."
-  else info "Docker DB not detected. Will use host MySQL at ${DB_HOST}:${DB_PORT}."; need_cmd mysql; fi
+  if ensure_docker_db; then
+    info "MySQL is running in Docker (service: db)."
+  else
+    info "Docker DB not detected. Will use host MySQL at ${DB_HOST}:${DB_PORT}."
+    need_cmd mysql
+  fi
 
   check_connectivity
 

--- a/scripts/dev-down.sh
+++ b/scripts/dev-down.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose down

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose up --build -d

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/scripts"
+
+sudo echo "Restarting SOSM"
+cd "$REPO_ROOT"
+git pull
+sudo "$SCRIPTS_DIR/dev-down.sh"
+sudo "$SCRIPTS_DIR/dev-up.sh"

--- a/server/app.js
+++ b/server/app.js
@@ -1,107 +1,105 @@
 const express = require('express');
 const path = require('path');
-const app = express();
-
 const multer = require('multer');
+const bodyParser = require('body-parser');
+const fs = require('fs');
 
 require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 
-console.log('[DB CHECK]', {
-  DIALECT: process.env.DB_DIALECT,
-  HOST: process.env.DB_HOST,
-  PORT: process.env.DB_PORT,
-  USER: process.env.DB_USER ? '(set)' : '(missing)',
-  PASS: process.env.DB_PASS ? '(set)' : '(missing)',
-  NAME: process.env.DB_NAME,
-});
-
-const bodyParser = require('body-parser');
 const select = require('./old_helpers/select.js');
 const graph = require('./old_helpers/graph.js');
 const update = require('./old_helpers//update.js');
 const backup = require('./old_helpers//backup.js');
-
 const images = require('./old_helpers//images.js');
-const fs = require('fs');
 
-// Serve static assets (css, js, images, etc.)
-app.use(express.static(path.join(__dirname, '..', 'public')));
+function createImageUpload() {
+  const storage = multer.diskStorage({
+    destination: (req, file, cb) => cb(null, path.join(__dirname, '..', 'public', 'images')),
+    filename: (req, file, cb) => {
+      const safe = Date.now() + '-' + file.originalname.replace(/[^a-zA-Z0-9._-]/g, '_');
+      cb(null, safe);
+    }
+  });
 
-app.get('/', (req, res) => {
-    //res.statusCode = 200;
-    //res.setHeader('Content-Type', 'text/html');
-    fs.createReadStream('index.html').pipe(res);
-    res.sendFile(path.join(__dirname, '..', 'public', 'index.html'));
+  return multer({
+    storage,
+    limits: { fileSize: 10 * 1024 * 1024 },
+    fileFilter: (req, file, cb) => {
+      const ok = /^(image\/png|image\/jpe?g|image\/gif|image\/svg\+xml|image\/webp)$/i.test(file.mimetype);
+      cb(ok ? null : new Error('Only image files are allowed'), ok);
+    }
+  });
+}
 
-})
+function createApp() {
+  const app = express();
 
-// API routes
-app.use('/api', require('./routes/images.routes.js'));
-app.use('/api', require('./routes/interfaces.routes.js'));
+  console.log('[DB CHECK]', {
+    DIALECT: process.env.DB_DIALECT,
+    HOST: process.env.DB_HOST,
+    PORT: process.env.DB_PORT,
+    USER: process.env.DB_USER ? '(set)' : '(missing)',
+    PASS: process.env.DB_PASS ? '(set)' : '(missing)',
+    NAME: process.env.DB_NAME,
+  });
 
+  const PUBLIC_DIR = path.join(__dirname, '..', 'public');
+  const IMAGES_DIR = path.join(PUBLIC_DIR, 'images');
 
-//Serve images
-const IMAGES_DIR = path.join(__dirname, '..', 'www', 'images');
-app.use('/images', express.static(IMAGES_DIR, {
-  // Optional: cache 1 day
-  maxAge: '1d',
-  // Basic security headers (optional)
-  setHeaders: (res) => {
-    res.setHeader('X-Content-Type-Options', 'nosniff');
-  }
-}));
+  app.use(express.static(PUBLIC_DIR));
+  app.use('/images', express.static(IMAGES_DIR, {
+    maxAge: '1d',
+    setHeaders: (res) => {
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+    }
+  }));
 
-app.use('/assets', express.static('assets'));
-app.use('/css', express.static('css'));
-app.use('/js', express.static('js'));
-app.use('/classes', express.static('classes'));
-app.use(bodyParser.urlencoded({ extended: true }));
+  app.use('/assets', express.static(path.join(PUBLIC_DIR, 'assets')));
+  app.use('/css', express.static(path.join(PUBLIC_DIR, 'css')));
+  app.use('/js', express.static(path.join(PUBLIC_DIR, 'js')));
+  app.use('/classes', express.static(path.join(PUBLIC_DIR, 'classes')));
 
-app.use(express.json());
+  app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(express.json());
 
-//Add or update nodes and features
-app.post('/update.json', update.switch);
+  app.get('/', (req, res) => {
+    const indexPath = path.join(PUBLIC_DIR, 'index.html');
+    if (!fs.existsSync(indexPath)) {
+      return res.status(500).send('Missing public/index.html');
+    }
+    return res.sendFile(indexPath);
+  });
 
-//Basic select statements
-app.post('/select.json', select.switch)
-app.post('/graph.json', graph.switch)
+  // New API routes
+  app.use('/api', require('./routes/images.routes.js'));
+  app.use('/api', require('./routes/interfaces.routes.js'));
 
-//Generate all the insert statements required to replicate the database
-app.get('/backup.txt', backup.run)
+  // Legacy endpoints retained for backwards compatibility
+  app.post('/update.json', update.switch);
+  app.post('/select.json', select.switch);
+  app.post('/graph.json', graph.switch);
+  app.get('/backup.txt', backup.run);
+  app.get('/images.json', images.getImages);
 
-app.get('/images.json', images.getImages);
+  const upload = createImageUpload();
+  app.post('/upload-image', upload.single('image'), (req, res) => {
+    if (!req.file) return res.status(400).json({ error: 'No file uploaded' });
+    return res.json({ ok: true, file: '/images/' + req.file.filename });
+  });
 
+  app.use((err, req, res, next) => {
+    console.error(err);
+    const status = err.statusCode || 400;
+    res.status(status).json({
+      error: {
+        code: err.code || 'BAD_REQUEST',
+        message: err.message || 'Invalid request'
+      }
+    });
+  });
 
-//Error handler
-app.use((err, req, res, next) => {
-  console.error(err);
-  const status = err.statusCode || 400;
-  res.status(status).json({ error: { code: err.code || 'BAD_REQUEST', message: err.message || 'Invalid request' } });
-});
+  return app;
+}
 
-// configure multer storage
-const storage = multer.diskStorage({
-  destination: (req, file, cb) => cb(null, path.join(__dirname, 'images')),
-  filename: (req, file, cb) => {
-    const safe = Date.now() + '-' + file.originalname.replace(/[^a-zA-Z0-9._-]/g, '_');
-    cb(null, safe);
-  }
-});
-const upload = multer({
-  storage,
-  limits: { fileSize: 10 * 1024 * 1024 },
-  fileFilter: (req, file, cb) => {
-    const ok = /^(image\/png|image\/jpe?g|image\/gif|image\/svg\+xml|image\/webp)$/i.test(file.mimetype);
-    cb(ok ? null : new Error('Only image files are allowed'), ok);
-  }
-});
-
-// POST /upload-image (field: "image")
-app.post('/upload-image', upload.single('image'), (req, res) => {
-  if (!req.file) return res.status(400).json({ error: 'No file uploaded' });
-  res.json({ ok: true, file: '/images/' + req.file.filename });
-});
-
-
-
-module.exports = app;
+module.exports = createApp();
+module.exports.createApp = createApp;


### PR DESCRIPTION
### Motivation
- Prevent host port collisions and simplify local Docker usage by moving the default app host port away from 80 and 3000 to `3001` and documenting the change. 
- Provide a portable way to export/import private local test data for offline development and faster restore workflows. 
- Improve the server code structure for clarity and compatibility with the updated public asset layout and routing. 

### Description
- Updated `.env.example` and `docker-compose.yaml` to use `APP_PORT=3001`, added a dedicated `sosm_net` bridge network, and adjusted service port mappings and container env fallbacks. 
- Refreshed documentation in `README.md`, `docs/dev/runSOSM.md`, `docs/dev/deploySOSM.md`, `docs/index.md` and added a new `docs/dev/dataPacks.md` to describe Docker quick-start and data pack workflows. 
- Added data pack tooling: `scripts/dataPackExport.sh` and `scripts/dataPackImport.sh`, and exposed new npm scripts `data:export` and `data:import` in `package.json`. 
- Refactored `server/app.js` into a `createApp()` factory, consolidated static paths under `public/`, changed image upload destination to `public/images`, improved error handling, and exported `createApp` for reuse. 

### Testing
- No automated unit tests were added or modified; the existing `npm test` entry remains a placeholder that emits an error message. 
- Validated `docker-compose.yaml` structural changes locally (compose config) to ensure syntax and service/network definitions are correct. 
- Manual smoke checks performed: starting services with `docker compose up -d` and accessing the app and Adminer endpoints to confirm the updated port and routing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e434d04f38832998a34d234514c8c8)