### PR TITLE
Consolidate shell helpers into shared lib; remove Adminer from compose and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,10 @@ docker compose up -d
 docker compose ps
 ```
 
-Network note: Compose now creates a dedicated bridge network named `sosm_net` for container-to-container communication (`server` ↔ `db` ↔ `adminer`).
+Network note: Compose creates a dedicated bridge network named `sosm_net` for container-to-container communication between `server` and `db`.
 
 ### 4) Open the app
 - App: `http://localhost:${APP_PORT:-3001}`
-- Adminer (optional): `http://localhost:8080`
 
 ### 5) (Optional) Load sample data
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,17 +50,6 @@ services:
     networks:
       - sosm_net
 
-  # Optional: web DB UI at http://localhost:8080
-  adminer:
-    image: adminer:latest
-    container_name: sosm_adminer
-    depends_on:
-      - db
-    ports:
-      - "8080:8080"
-    networks:
-      - sosm_net
-
 volumes:
   dbdata: {}
 

--- a/docs/dev/priorities.md
+++ b/docs/dev/priorities.md
@@ -9,7 +9,7 @@ Work is ordered from **foundations** (must-haves) → **core features** (to enab
 
 - [ ] **Containerisation**
   - [ ] Add Dockerfile for the app (`www/`).
-  - [ ] Add `docker-compose.yml` with services: `app`, `db`, (optional) `adminer`.
+  - [ ] Add `docker-compose.yml` with services: `app`, `db`.
   - [ ] Use `.env` for DB + app config (no hardcoded credentials).
   - [ ] Ensure MySQL persistence with named volume (`dbdata`).
   - [ ] Modify `helpers/db.js` to read from env vars.

--- a/docs/dev/runSOSM.md
+++ b/docs/dev/runSOSM.md
@@ -62,11 +62,10 @@ docker compose logs -f
 
 # service‑specific
 docker compose logs -f db
-docker compose logs -f adminer
 docker compose logs -f server
 ```
 
-> Adminer (optional DB UI) is at **http://localhost:8080** once up. The app is exposed on **http://localhost:${APP_PORT:-3001}** (default 3001) with Compose mapping host `${APP_PORT}` to container port `3000`.
+> The app is exposed on **http://localhost:${APP_PORT:-3001}** (default 3001) with Compose mapping host `${APP_PORT}` to container port `3000`.
 
 ---
 

--- a/scripts/backupTestData.sh
+++ b/scripts/backupTestData.sh
@@ -13,69 +13,24 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 ENV_FILE="${REPO_ROOT}/.env"
+COMMON_LIB="${SCRIPT_DIR}/lib/sosm-common.sh"
 
 WWW_DIR="${REPO_ROOT}/public"
 IMG_SRC="${WWW_DIR}/images"
 
 # Defaults (can be overridden)
-DEFAULT_DEST="${REPO_ROOT}/testData"
 DEST_DIR="${DEST_DIR:-}"                       # env override
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yml}"
 YES="${YES:-false}"
 
+[[ -f "${COMMON_LIB}" ]] || { echo "ERROR: Missing shared script library: ${COMMON_LIB}" >&2; exit 1; }
+# shellcheck source=lib/sosm-common.sh
+source "${COMMON_LIB}"
+
 # ---------- helpers ----------
 
-die(){ echo "ERROR: $*" >&2; exit 1; }
-info(){ echo ">> $*"; }
-
-need_cmd() { command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"; }
-
-confirm() {
-  if [[ "${YES}" == "true" ]]; then return 0; fi
-  read -r -p "$1 [y/N] " ans
-  [[ "${ans}" == "y" || "${ans}" == "Y" ]]
-}
-
-load_env() {
-  [[ -f "${ENV_FILE}" ]] || die "Missing .env at ${ENV_FILE}"
-  # shellcheck disable=SC2046
-  export $(grep -v '^[[:space:]]*#' "${ENV_FILE}" | grep -E '^[A-Za-z0-9_]+=' | xargs) || true
-  : "${DB_NAME:?Missing DB_NAME in .env}"
-  : "${DB_USER:?Missing DB_USER in .env}"
-  : "${DB_PASS:?Missing DB_PASS in .env}"
-  export DB_HOST="${DB_HOST:-127.0.0.1}"
-  export DB_PORT="${DB_PORT:-3306}"
-}
-
-resolve_compose_file() {
-  if [[ -f "${REPO_ROOT}/${COMPOSE_FILE}" ]]; then
-    return
-  fi
-
-  local alt
-  if [[ "${COMPOSE_FILE}" == *.yaml ]]; then
-    alt="${COMPOSE_FILE%.yaml}.yml"
-  elif [[ "${COMPOSE_FILE}" == *.yml ]]; then
-    alt="${COMPOSE_FILE%.yml}.yaml"
-  else
-    alt=""
-  fi
-
-  if [[ -n "${alt}" && -f "${REPO_ROOT}/${alt}" ]]; then
-    info "Compose file '${COMPOSE_FILE}' not found, using '${alt}'"
-    COMPOSE_FILE="${alt}"
-  fi
-}
-
 docker_db_running() {
-  if ! command -v docker >/dev/null 2>&1; then return 1; fi
-  docker compose version >/dev/null 2>&1 || return 1
-  local cid
-  cid="$(cd "${REPO_ROOT}" && docker compose -f "${COMPOSE_FILE}" ps -q db || true)"
-  [[ -n "${cid}" ]] || return 1
-  local st
-  st="$(docker inspect -f '{{.State.Running}}' "${cid}" 2>/dev/null || echo false)"
-  [[ "${st}" == "true" ]]
+  sosm_docker_service_running "${REPO_ROOT}" "${COMPOSE_FILE}" "db"
 }
 
 mysql_probe_host() {
@@ -121,16 +76,16 @@ choose_destination() {
   esac
 
   read -r -p "Enter the name of the folder to use inside ${base}: " folder_name
-  [[ -n "${folder_name}" ]] || die "Folder name cannot be empty."
+  [[ -n "${folder_name}" ]] || sosm_die "Folder name cannot be empty."
 
   DEST_DIR="${base}/${folder_name}"
 }
 
 ensure_destination() {
   if [[ -d "${DEST_DIR}" ]]; then
-    info "Destination '${DEST_DIR}' already exists."
-    if ! confirm "Do you want to overwrite its contents?"; then
-      die "Aborted by user."
+    sosm_info "Destination '${DEST_DIR}' already exists."
+    if ! sosm_confirm "${YES}" "Do you want to overwrite its contents?"; then
+      sosm_die "Aborted by user."
     fi
   fi
   mkdir -p "${DEST_DIR}"
@@ -138,9 +93,9 @@ ensure_destination() {
 
 sync_images() {
   local dst="${DEST_DIR}/images"
-  [[ -d "${IMG_SRC}" ]] || die "Image source not found: ${IMG_SRC}"
+  [[ -d "${IMG_SRC}" ]] || sosm_die "Image source not found: ${IMG_SRC}"
   mkdir -p "${dst}"
-  info "Syncing images: ${IMG_SRC}/ -> ${dst}/"
+  sosm_info "Syncing images: ${IMG_SRC}/ -> ${dst}/"
   if command -v rsync >/dev/null 2>&1; then
     rsync -a --delete "${IMG_SRC}/" "${dst}/"
   else
@@ -153,11 +108,11 @@ dump_db() {
   local out="${DEST_DIR}/schema.sql"
   mkdir -p "${DEST_DIR}"
   local tmp="${out}.tmp"
-  info "Dumping database '${DB_NAME}' to ${out}"
+  sosm_info "Dumping database '${DB_NAME}' to ${out}"
   if docker_db_running; then
     mysqldump_docker > "${tmp}"
   else
-    need_cmd mysqldump
+    sosm_need_cmd mysqldump
     mysqldump_host > "${tmp}"
   fi
   mv -f "${tmp}" "${out}"
@@ -194,14 +149,14 @@ parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --dest)
-        shift; [[ $# -gt 0 ]] || die "--dest requires a path"
+        shift; [[ $# -gt 0 ]] || sosm_die "--dest requires a path"
         DEST_DIR="$1"; shift;;
       --yes)
         YES=true; shift;;
       -h|--help)
         usage; exit 0;;
       *)
-        die "Unknown argument: $1 (use --help)";;
+        sosm_die "Unknown argument: $1 (use --help)";;
     esac
   done
 }
@@ -209,24 +164,22 @@ parse_args() {
 # ---------- main ----------
 
 main() {
-  need_cmd grep
+  sosm_need_cmd grep
   parse_args "$@"
-  load_env
-  resolve_compose_file
+  sosm_load_env "${ENV_FILE}"
+  sosm_resolve_compose_file "${REPO_ROOT}"
 
-  info "Checking database connectivity…"
+  sosm_info "Checking database connectivity…"
   if docker_db_running; then
-    if ! docker info >/dev/null 2>&1; then
-      die "Docker is installed but not accessible by this user. Try running with sudo or add your user to the docker group."
-    fi
-    info "Docker DB detected (service: db)."
+    sosm_require_docker_access
+    sosm_info "Docker DB detected (service: db)."
     mysql_probe_docker
   else
-    info "Using host MySQL at ${DB_HOST}:${DB_PORT}."
-    need_cmd mysql
+    sosm_info "Using host MySQL at ${DB_HOST}:${DB_PORT}."
+    sosm_need_cmd mysql
     mysql_probe_host
   fi
-  info "Database connectivity OK."
+  sosm_info "Database connectivity OK."
 
   choose_destination
   ensure_destination

--- a/scripts/deployTestData.sh
+++ b/scripts/deployTestData.sh
@@ -12,86 +12,33 @@ set -euo pipefail
 # Paths (resolve relative to this script)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-SQL_DIR="${REPO_ROOT}/server/sql"
 TEST_DIR="${REPO_ROOT}/testData"
 WWW_DIR="${REPO_ROOT}/public"
 ENV_FILE="${REPO_ROOT}/.env"
+COMMON_LIB="${SCRIPT_DIR}/lib/sosm-common.sh"
 
 # Options / env overrides
 YES="${YES:-false}"                               # non-interactive confirm: YES=true
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yml}" # docker compose file name
 TEST_NAME="${TEST_NAME:-}"                        # choose test folder non-interactively
 
+[[ -f "${COMMON_LIB}" ]] || { echo "ERROR: Missing shared script library: ${COMMON_LIB}" >&2; exit 1; }
+# shellcheck source=lib/sosm-common.sh
+source "${COMMON_LIB}"
+
 # ---------------- helpers ----------------------
-
-die() { echo "ERROR: $*" >&2; exit 1; }
-info(){ echo ">> $*"; }
-
-need_cmd() {
-  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
-}
-
-confirm() {
-  if [[ "${YES}" == "true" ]]; then return 0; fi
-  read -r -p "$1 [y/N] " ans
-  [[ "${ans}" == "y" || "${ans}" == "Y" ]]
-}
-
-load_env() {
-  [[ -f "${ENV_FILE}" ]] || die "Missing .env at ${ENV_FILE}"
-  # shellcheck disable=SC2046
-  export $(grep -v '^[[:space:]]*#' "${ENV_FILE}" | grep -E '^[A-Za-z0-9_]+=' | xargs) || true
-  : "${DB_NAME:?Missing DB_NAME in .env}"
-  : "${DB_USER:?Missing DB_USER in .env}"
-  : "${DB_PASS:?Missing DB_PASS in .env}"
-  export DB_HOST="${DB_HOST:-127.0.0.1}"
-  export DB_PORT="${DB_PORT:-3306}"
-}
-
-resolve_compose_file() {
-  if [[ -f "${REPO_ROOT}/${COMPOSE_FILE}" ]]; then
-    return
-  fi
-
-  local alt
-  if [[ "${COMPOSE_FILE}" == *.yaml ]]; then
-    alt="${COMPOSE_FILE%.yaml}.yml"
-  elif [[ "${COMPOSE_FILE}" == *.yml ]]; then
-    alt="${COMPOSE_FILE%.yml}.yaml"
-  else
-    alt=""
-  fi
-
-  if [[ -n "${alt}" && -f "${REPO_ROOT}/${alt}" ]]; then
-    info "Compose file '${COMPOSE_FILE}' not found, using '${alt}'"
-    COMPOSE_FILE="${alt}"
-  fi
-}
 
 docker_db_running() {
   # Returns 0 if a Compose service named "db" is up
-  if ! command -v docker >/dev/null 2>&1; then return 1; fi
-  docker compose version >/dev/null 2>&1 || return 1
-  # Run from repo root so compose can see the file
-  info "Running: docker compose -f ${COMPOSE_FILE} ps -q db"
-  (cd "${REPO_ROOT}" && docker compose -f "${COMPOSE_FILE}" ps -q db) >/dev/null 2>&1 || return 1
-  local cid
-  cid="$(cd "${REPO_ROOT}" && docker compose -f "${COMPOSE_FILE}" ps -q db || true)"
-  [[ -n "${cid}" ]] || return 1
-  # Check running status
-  local st
-  st="$(docker inspect -f '{{.State.Running}}' "${cid}" 2>/dev/null || echo false)"
-  [[ "${st}" == "true" ]]
+  sosm_info "Running: docker compose -f ${COMPOSE_FILE} ps -q db"
+  sosm_docker_service_running "${REPO_ROOT}" "${COMPOSE_FILE}" "db"
 }
 
 ensure_docker_db() {
   command -v docker >/dev/null 2>&1 || return 1
-  docker compose version >/dev/null 2>&1 || return 1
-  if ! docker info >/dev/null 2>&1; then
-    die "Docker is installed but not accessible by this user. Try 'sudo ./scripts/deployTestData.sh' or add your user to the docker group."
-  fi
+  sosm_require_docker_access || return 1
   if docker_db_running; then return 0; fi
-  info "Docker Compose detected but 'db' is not running. Attempting to start it…"
+  sosm_info "Docker Compose detected but 'db' is not running. Attempting to start it…"
   (cd "${REPO_ROOT}" && docker compose -f "${COMPOSE_FILE}" up -d db)
   docker_db_running
 }
@@ -113,21 +60,21 @@ mysql_exec_docker() {
 }
 
 check_connectivity() {
-  info "Checking DB connectivity as ${DB_USER}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+  sosm_info "Checking DB connectivity as ${DB_USER}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
   local probe="SELECT 1 as ok;"
   if docker_db_running; then
     echo "${probe}" | mysql_exec_docker "-"
   else
-    need_cmd mysql
+    sosm_need_cmd mysql
     echo "${probe}" | mysql_exec_host "-"
   fi
-  info "Database connectivity OK."
+  sosm_info "Database connectivity OK."
 }
 
 run_sql_file() {
   local file="${1}"
-  [[ -f "${file}" ]] || die "SQL file not found: ${file}"
-  info "Applying $(basename "${file}")"
+  [[ -f "${file}" ]] || sosm_die "SQL file not found: ${file}"
+  sosm_info "Applying $(basename "${file}")"
   if docker_db_running; then mysql_exec_docker "${file}"; else mysql_exec_host "${file}"; fi
 }
 
@@ -135,11 +82,11 @@ copy_images_from() {
   local src_images="${1}/images"
   local dest_images="${WWW_DIR}/images"
   if [[ -d "${src_images}" ]]; then
-    info "Copying images from ${src_images} -> ${dest_images}"
+    sosm_info "Copying images from ${src_images} -> ${dest_images}"
     mkdir -p "${dest_images}"
     cp -R "${src_images}/." "${dest_images}/"
   else
-    info "No images folder in ${1}; skipping image copy."
+    sosm_info "No images folder in ${1}; skipping image copy."
   fi
 }
 
@@ -201,26 +148,26 @@ run_all_sql_in_folder() {
   local case_dir="${1}"
   mapfile -t files < <(find "${case_dir}" -maxdepth 1 -type f -name "*.sql" | sort)
   if [[ ${#files[@]} -eq 0 ]]; then
-    info "No .sql files found in ${case_dir}"
+    sosm_info "No .sql files found in ${case_dir}"
     return 0
   fi
-  info "Executing ${#files[@]} SQL file(s) from $(basename "${case_dir}")"
+  sosm_info "Executing ${#files[@]} SQL file(s) from $(basename "${case_dir}")"
   for f in "${files[@]}"; do run_sql_file "${f}"; done
 }
 
 # ---------------- main -------------------------
 
 main() {
-  need_cmd grep
-  load_env
-  resolve_compose_file
+  sosm_need_cmd grep
+  sosm_load_env "${ENV_FILE}"
+  sosm_resolve_compose_file "${REPO_ROOT}"
 
-  info "Hybrid check: detecting Docker 'db' service…"
+  sosm_info "Hybrid check: detecting Docker 'db' service…"
   if ensure_docker_db; then
-    info "MySQL is running in Docker (service: db)."
+    sosm_info "MySQL is running in Docker (service: db)."
   else
-    info "Docker DB not detected. Will use host MySQL at ${DB_HOST}:${DB_PORT}."
-    need_cmd mysql
+    sosm_info "Docker DB not detected. Will use host MySQL at ${DB_HOST}:${DB_PORT}."
+    sosm_need_cmd mysql
   fi
 
   check_connectivity
@@ -237,15 +184,15 @@ main() {
   echo "Target  : DB=${DB_NAME}  public/images/"
   echo "----------------------------------------"
 
-  if ! confirm "Proceed with loading '${case_name}' into '${DB_NAME}'?"; then
-    info "Aborted."
+  if ! sosm_confirm "${YES}" "Proceed with loading '${case_name}' into '${DB_NAME}'?"; then
+    sosm_info "Aborted."
     exit 0
   fi
 
   run_all_sql_in_folder "${case_dir}"
   copy_images_from "${case_dir}"
 
-  info "Done."
+  sosm_info "Done."
 }
 
 main "$@"

--- a/scripts/lib/sosm-common.sh
+++ b/scripts/lib/sosm-common.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# Shared helpers for SOSM shell scripts.
+
+sosm_die() { echo "ERROR: $*" >&2; exit 1; }
+sosm_info() { echo ">> $*"; }
+
+sosm_need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || sosm_die "Missing required command: $1"
+}
+
+sosm_confirm() {
+  local yes="${1}"
+  local prompt="${2}"
+  if [[ "${yes}" == "true" ]]; then
+    return 0
+  fi
+  local ans
+  read -r -p "${prompt} [y/N] " ans
+  [[ "${ans}" == "y" || "${ans}" == "Y" ]]
+}
+
+sosm_load_env() {
+  local env_file="${1}"
+  [[ -f "${env_file}" ]] || sosm_die "Missing .env at ${env_file}"
+
+  local line key value
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    [[ "${line}" =~ ^[[:space:]]*$ ]] && continue
+    [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+    [[ "${line}" == *=* ]] || continue
+
+    key="${line%%=*}"
+    value="${line#*=}"
+
+    key="${key#"${key%%[![:space:]]*}"}"
+    key="${key%"${key##*[![:space:]]}"}"
+
+    [[ "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    export "${key}=${value}"
+  done < "${env_file}"
+
+  : "${DB_NAME:?Missing DB_NAME in .env}"
+  : "${DB_USER:?Missing DB_USER in .env}"
+  : "${DB_PASS:?Missing DB_PASS in .env}"
+  export DB_HOST="${DB_HOST:-127.0.0.1}"
+  export DB_PORT="${DB_PORT:-3306}"
+}
+
+sosm_resolve_compose_file() {
+  local repo_root="${1}"
+
+  if [[ -f "${repo_root}/${COMPOSE_FILE}" ]]; then
+    return
+  fi
+
+  local alt
+  if [[ "${COMPOSE_FILE}" == *.yaml ]]; then
+    alt="${COMPOSE_FILE%.yaml}.yml"
+  elif [[ "${COMPOSE_FILE}" == *.yml ]]; then
+    alt="${COMPOSE_FILE%.yml}.yaml"
+  else
+    alt=""
+  fi
+
+  if [[ -n "${alt}" && -f "${repo_root}/${alt}" ]]; then
+    sosm_info "Compose file '${COMPOSE_FILE}' not found, using '${alt}'"
+    COMPOSE_FILE="${alt}"
+  fi
+}
+
+sosm_docker_service_running() {
+  local repo_root="${1}"
+  local compose_file="${2}"
+  local service="${3}"
+
+  if ! command -v docker >/dev/null 2>&1; then return 1; fi
+  docker compose version >/dev/null 2>&1 || return 1
+
+  local cid
+  cid="$(cd "${repo_root}" && docker compose -f "${compose_file}" ps -q "${service}" || true)"
+  [[ -n "${cid}" ]] || return 1
+
+  local running
+  running="$(docker inspect -f '{{.State.Running}}' "${cid}" 2>/dev/null || echo false)"
+  [[ "${running}" == "true" ]]
+}
+
+sosm_require_docker_access() {
+  docker compose version >/dev/null 2>&1 || return 1
+  if ! docker info >/dev/null 2>&1; then
+    sosm_die "Docker is installed but not accessible by this user. Try running with sudo or add your user to the docker group."
+  fi
+}

--- a/scripts/setupEnvironment.sh
+++ b/scripts/setupEnvironment.sh
@@ -16,18 +16,13 @@ ENV_FILE="${REPO_ROOT}/.env"
 WWW_DIR="${REPO_ROOT}/www"
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yml}"
 YES="${YES:-false}"
+COMMON_LIB="${SCRIPT_DIR}/lib/sosm-common.sh"
 
-info(){ echo ">> $*"; }
+[[ -f "${COMMON_LIB}" ]] || { echo "ERROR: Missing shared script library: ${COMMON_LIB}" >&2; exit 1; }
+# shellcheck source=lib/sosm-common.sh
+source "${COMMON_LIB}"
+
 warn(){ echo "!! $*" >&2; }
-die(){ echo "ERROR: $*" >&2; exit 1; }
-
-need_cmd() { command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"; }
-
-confirm() {
-  if [[ "${YES}" == "true" ]]; then return 0; fi
-  read -r -p "$1 [y/N] " ans
-  [[ "${ans}" == "y" || "${ans}" == "Y" ]]
-}
 
 ask_mode() {
   echo "Choose environment mode:"
@@ -40,7 +35,7 @@ ask_mode() {
     2) MODE="native" ;;
     *) MODE="hybrid" ;;
   esac
-  info "Selected mode: ${MODE}"
+  sosm_info "Selected mode: ${MODE}"
 }
 
 apt_update_once=false
@@ -55,11 +50,11 @@ apt_install() {
 
 ensure_docker() {
   if command -v docker >/dev/null 2>&1 && command -v docker compose >/dev/null 2>&1; then
-    info "Docker + compose already installed."
+    sosm_info "Docker + compose already installed."
     return
   fi
-  if ! confirm "Docker is not installed. Install Docker Engine + compose plugin now?"; then
-    die "Docker is required for Hybrid mode."
+  if ! sosm_confirm "${YES}" "Docker is not installed. Install Docker Engine + compose plugin now?"; then
+    sosm_die "Docker is required for Hybrid mode."
   fi
   # Minimal Docker install for Ubuntu
   sudo apt-get remove -y docker docker-engine docker.io containerd runc || true
@@ -72,28 +67,28 @@ ensure_docker() {
   sudo apt-get update -y
   sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
   sudo usermod -aG docker "$USER" || true
-  info "Docker installed. You may need to log out/in for group changes to apply."
+  sosm_info "Docker installed. You may need to log out/in for group changes to apply."
 }
 
 ensure_node() {
   if command -v node >/dev/null 2>&1; then
-    info "Node.js present: $(node -v)"
+    sosm_info "Node.js present: $(node -v)"
   else
-    info "Installing Node.js LTS via apt (Ubuntu)..."
+    sosm_info "Installing Node.js LTS via apt (Ubuntu)..."
     apt_install nodejs npm
   fi
   if ! command -v npx >/dev/null 2>&1; then
-    info "Installing npm (for npx)..."
+    sosm_info "Installing npm (for npx)..."
     apt_install npm
   fi
 }
 
 ensure_mysql_native() {
   if command -v mysql >/dev/null 2>&1 && command -v mysqldump >/dev/null 2>&1; then
-    info "MySQL client/server appears installed."
+    sosm_info "MySQL client/server appears installed."
   else
-    if ! confirm "Install MySQL Server locally (native mode)?"; then
-      die "MySQL Server required for native mode."
+    if ! sosm_confirm "${YES}" "Install MySQL Server locally (native mode)?"; then
+      sosm_die "MySQL Server required for native mode."
     fi
     apt_install mysql-server
   fi
@@ -102,10 +97,10 @@ ensure_mysql_native() {
 
 create_env_if_missing() {
   if [[ -f "${ENV_FILE}" ]]; then
-    info ".env exists; will reuse. ($(basename "${ENV_FILE}"))"
+    sosm_info ".env exists; will reuse. ($(basename "${ENV_FILE}"))"
     return
   fi
-  info "Creating default .env at ${ENV_FILE}"
+  sosm_info "Creating default .env at ${ENV_FILE}"
   cat > "${ENV_FILE}" <<'EOF'
 APP_PORT=3000
 DB_DIALECT=mysql
@@ -118,59 +113,29 @@ DB_ROOT_PASS=rootpass
 EOF
 }
 
-load_env() {
-  # shellcheck disable=SC2046
-  export $(grep -v '^[[:space:]]*#' "${ENV_FILE}" | grep -E '^[A-Za-z0-9_]+=' | xargs) || true
-  : "${DB_NAME:?Missing DB_NAME in .env}"
-  : "${DB_USER:?Missing DB_USER in .env}"
-  : "${DB_PASS:?Missing DB_PASS in .env}"
-  export DB_HOST="${DB_HOST:-127.0.0.1}"
-  export DB_PORT="${DB_PORT:-3306}"
-}
-
-resolve_compose_file() {
-  if [[ -f "${REPO_ROOT}/${COMPOSE_FILE}" ]]; then
-    return
-  fi
-
-  local alt
-  if [[ "${COMPOSE_FILE}" == *.yaml ]]; then
-    alt="${COMPOSE_FILE%.yaml}.yml"
-  elif [[ "${COMPOSE_FILE}" == *.yml ]]; then
-    alt="${COMPOSE_FILE%.yml}.yaml"
-  else
-    alt=""
-  fi
-
-  if [[ -n "${alt}" && -f "${REPO_ROOT}/${alt}" ]]; then
-    info "Compose file '${COMPOSE_FILE}' not found, using '${alt}'"
-    COMPOSE_FILE="${alt}"
-  fi
-}
-
 docker_db_up() {
   if [[ ! -f "${REPO_ROOT}/${COMPOSE_FILE}" ]]; then
-    die "docker-compose file not found: ${REPO_ROOT}/${COMPOSE_FILE}"
-  }
-  info "Starting db service via docker compose"
+    sosm_die "docker-compose file not found: ${REPO_ROOT}/${COMPOSE_FILE}"
+  fi
+  sosm_info "Starting db service via docker compose"
   (cd "${REPO_ROOT}" && docker compose -f "${COMPOSE_FILE}" up -d db)
 }
 
 docker_db_probe() {
-  info "Probing DB (docker)…"
+  sosm_info "Probing DB (docker)…"
   (cd "${REPO_ROOT}" && docker compose -f "${COMPOSE_FILE}" exec -T db \
     mysql -u"${DB_USER}" --password="${DB_PASS}" -e "SELECT 1" "${DB_NAME}") >/dev/null
 }
 
 native_db_prepare() {
-  info "Ensuring database and user exist (native)…"
+  sosm_info "Ensuring database and user exist (native)…"
   sudo mysql -e "CREATE DATABASE IF NOT EXISTS \`${DB_NAME}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
   sudo mysql -e "CREATE USER IF NOT EXISTS '${DB_USER}'@'%' IDENTIFIED BY '${DB_PASS}';"
   sudo mysql -e "GRANT ALL PRIVILEGES ON \`${DB_NAME}\`.* TO '${DB_USER}'@'%'; FLUSH PRIVILEGES;"
 }
 
 native_db_probe() {
-  info "Probing DB (native)…"
+  sosm_info "Probing DB (native)…"
   mysql --protocol=TCP -h"${DB_HOST}" -P"${DB_PORT}" -u"${DB_USER}" --password="${DB_PASS}" -e "SELECT 1" "${DB_NAME}" >/dev/null
 }
 
@@ -188,18 +153,18 @@ require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 
 install_node_modules() {
   if [[ ! -d "${WWW_DIR}" ]]; then
-    die "www directory not found at ${WWW_DIR}"
+    sosm_die "www directory not found at ${WWW_DIR}"
   fi
-  info "Installing Node dependencies in www/"
+  sosm_info "Installing Node dependencies in www/"
   (cd "${WWW_DIR}" && npm install && npm install --save dotenv && npx --yes nodemon -v >/dev/null 2>&1 || npm install -D nodemon)
 }
 
 main() {
-  need_cmd grep
+  sosm_need_cmd grep
   ask_mode
   create_env_if_missing
-  load_env
-  resolve_compose_file
+  sosm_load_env "${ENV_FILE}"
+  sosm_resolve_compose_file "${REPO_ROOT}"
   ensure_node
 
   if [[ "${MODE}" == "hybrid" ]]; then
@@ -218,7 +183,7 @@ main() {
   install_node_modules
   ensure_dotenv_in_app
 
-  info "Environment setup complete."
+  sosm_info "Environment setup complete."
   echo
   echo "Next steps:"
   echo "  - Start the API:   (cd www && npx nodemon app.js)"

--- a/scripts/test-sosm-common.sh
+++ b/scripts/test-sosm-common.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_LIB="${SCRIPT_DIR}/lib/sosm-common.sh"
+
+# shellcheck source=lib/sosm-common.sh
+source "${COMMON_LIB}"
+
+pass() { echo "PASS: $*"; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+test_load_env_parsing() {
+  local tmp_env
+  tmp_env="$(mktemp)"
+  cat > "${tmp_env}" <<'EOF'
+# comment
+DB_NAME=db_sosm
+DB_USER=sosmUser
+DB_PASS=sosm_pass
+VALUE_WITH_SPACES=hello world
+INVALID KEY=ignored
+EOF
+
+  sosm_load_env "${tmp_env}"
+  rm -f "${tmp_env}"
+
+  [[ "${DB_NAME}" == "db_sosm" ]] || fail "DB_NAME should be parsed"
+  [[ "${DB_USER}" == "sosmUser" ]] || fail "DB_USER should be parsed"
+  [[ "${DB_PASS}" == "sosm_pass" ]] || fail "DB_PASS should be parsed"
+  [[ "${VALUE_WITH_SPACES}" == "hello world" ]] || fail "VALUE_WITH_SPACES should preserve spaces"
+  pass "sosm_load_env parses expected keys"
+}
+
+test_resolve_compose_file() {
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  COMPOSE_FILE="docker-compose.yaml"
+  touch "${tmp_dir}/docker-compose.yml"
+
+  sosm_resolve_compose_file "${tmp_dir}"
+  rm -rf "${tmp_dir}"
+
+  [[ "${COMPOSE_FILE}" == "docker-compose.yml" ]] || fail "COMPOSE_FILE should fallback to .yml"
+  pass "sosm_resolve_compose_file handles yaml/yml fallback"
+}
+
+main() {
+  test_load_env_parsing
+  test_resolve_compose_file
+  echo "All sosm-common tests passed."
+}
+
+main "$@"


### PR DESCRIPTION
### Motivation

- Reduce duplicated shell helper code across scripts by introducing a single shared library for reliability and maintainability.
- Standardise env loading, compose-file detection and docker/service checks used by multiple helper scripts.
- Simplify the Docker setup by removing the optional Adminer service and cleaning up docs to match the compose file.

### Description

- Add `scripts/lib/sosm-common.sh` which exposes shared helpers such as `sosm_die`, `sosm_info`, `sosm_need_cmd`, `sosm_confirm`, `sosm_load_env`, `sosm_resolve_compose_file`, `sosm_docker_service_running`, and `sosm_require_docker_access`.
- Refactor `scripts/backupTestData.sh`, `scripts/deployTestData.sh`, and `scripts/setupEnvironment.sh` to source the new common lib and replace local helper implementations with calls to the `sosm_*` functions and simplified logic.
- Remove the `adminer` service from `docker-compose.yml` and remove/update Adminer references in `README.md` and `docs/dev/runSOSM.md`.
- Add `scripts/test-sosm-common.sh` to provide basic automated tests for environment parsing and compose-file fallback behaviour in the common library.

### Testing

- Ran `scripts/test-sosm-common.sh`, which executes `test_load_env_parsing` and `test_resolve_compose_file`, and the script completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c744497c8329ae04a7c3f25ee2bb)